### PR TITLE
centered random text

### DIFF
--- a/src/app/(pages)/scoreboard/page.tsx
+++ b/src/app/(pages)/scoreboard/page.tsx
@@ -81,13 +81,19 @@ export default function ScoreboardPage() {
       <Title title="General" />
 
       <div className="mx-auto w-full max-w-7xl overflow-x-auto px-4 scrollbar-thin scrollbar-track-gray-700 scrollbar-thumb-roboblue">
-        <table className="min-w-full border-collapse text-white">
+        <table className="w-full table-fixed border-collapse text-white">
           <colgroup>
-            <col />
-            <col span={3} />
-            <col span={3} />
-            <col span={3} />
-            <col />
+            <col className="w-48" />
+            <col className="w-16" />
+            <col className="w-16" />
+            <col className="w-16" />
+            <col className="w-16" />
+            <col className="w-16" />
+            <col className="w-16" />
+            <col className="w-16" />
+            <col className="w-16" />
+            <col className="w-16" />
+            <col className="w-20" />
           </colgroup>
           <thead>
             <tr className="border-b border-gray-700">

--- a/src/app/_components/random-text.tsx
+++ b/src/app/_components/random-text.tsx
@@ -15,5 +15,5 @@ export default function RandomText() {
     }, 100);
     return () => clearInterval(interval);
   }, []);
-  return <p className="min-w-5 max-w-5">{randomText}</p>;
+  return <span className="inline-block w-8 text-center">{randomText}</span>;
 }


### PR DESCRIPTION
`Random-text` wasn't centered in the table. Tried centering but it changed the width of the column repeatedly. Fixed it for the whole table which also changed depending on the score.
<img width="1829" height="1016" alt="image" src="https://github.com/user-attachments/assets/fc4d4a3f-7dd3-4c50-bdbf-3c006a871f49" />
